### PR TITLE
Add VarHandleValues classes to permits sub-class list of VarHandle

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/VarHandle.java
+++ b/src/java.base/share/classes/java/lang/invoke/VarHandle.java
@@ -505,7 +505,10 @@ public abstract sealed class VarHandle implements Constable
              VarHandleReferences.FieldStaticReadOnly,
              VarHandleShorts.Array,
              VarHandleShorts.FieldInstanceReadOnly,
-             VarHandleShorts.FieldStaticReadOnly {
+             VarHandleShorts.FieldStaticReadOnly,
+             VarHandleValues.Array,
+             VarHandleValues.FieldInstanceReadOnly,
+             VarHandleValues.FieldStaticReadOnly {
     final VarForm vform;
     final boolean exact;
 


### PR DESCRIPTION
OpenJDK next repo has changed VarHandle to be sealed class.
VarHandleValues classes are only used in Valhalla, so they are not in
the subclass list of VarHandle in the OpenJDK next change. Add
VarHandleValues classes into sub-class list of VarHandle in Valhalla
repo.

issue https://github.com/eclipse-openj9/openj9/issues/14839

Signed-off-by: Hang Shao <hangshao@ca.ibm.com>