### PR TITLE
Resolve merge conflict of valhalla repo and jdkNext repo

### DIFF
--- a/make/test/JtregNativeHotspot.gmk
+++ b/make/test/JtregNativeHotspot.gmk
@@ -875,9 +875,11 @@ BUILD_HOTSPOT_JTREG_EXECUTABLES_LIBS_exesigtest := -ljvm
 
 ifeq ($(call isTargetOs, windows), true)
     BUILD_HOTSPOT_JTREG_EXECUTABLES_CFLAGS_exeFPRegs := -MT
-    BUILD_HOTSPOT_JTREG_EXCLUDE += exesigtest.c libterminatedThread.c libTestJNI.c libCompleteExit.c libTestPsig.c
+    BUILD_HOTSPOT_JTREG_EXCLUDE += exesigtest.c libterminatedThread.c libTestJNI.c libCompleteExit.c
     BUILD_HOTSPOT_JTREG_LIBRARIES_LIBS_libatExit := jvm.lib
+    BUILD_HOTSPOT_JTREG_EXECUTABLES_LIBS_exedaemonDestroy := jvm.lib
 else
+    BUILD_HOTSPOT_JTREG_EXECUTABLES_LIBS_exedaemonDestroy := -ljvm
     BUILD_HOTSPOT_JTREG_LIBRARIES_LIBS_libbootclssearch_agent += -lpthread
     BUILD_HOTSPOT_JTREG_LIBRARIES_LIBS_libsystemclssearch_agent += -lpthread
     BUILD_HOTSPOT_JTREG_LIBRARIES_LIBS_libgetsysprop001 += -lpthread

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Flags.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Flags.java
@@ -158,7 +158,11 @@ public class Flags {
     public static final int BLOCK            = 1<<20;
 
     /** Marks a type as a value class */
-    public static final int VALUE_CLASS  = 1<<21;
+    public static final int VALUE_CLASS  = 1<<20;
+
+    /** Flag is set for ClassSymbols that are being compiled from source.
+     */
+    public static final int FROM_SOURCE      = 1<<21; //ClassSymbols
 
     /** Flag is set for nested classes that do not access instance members
      *  or `this' of an outer class and therefore don't need to be passed
@@ -524,6 +528,7 @@ public class Flags {
             }
         },
         BLOCK(Flags.BLOCK),
+        FROM_SOURCE(Flags.FROM_SOURCE),
         ENUM(Flags.ENUM),
         MANDATED(Flags.MANDATED),
         PRIMITIVE(Flags.PRIMITIVE_CLASS),

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -102,6 +102,8 @@ applications/jcstress/copy.java 8229852 linux-all
 
 containers/docker/TestJcmd.java 8278102 linux-all
 
+runtime/cds/appcds/cacheObject/ArchivedEnumTest.java 8292499 generic-all
+
 # Valhalla
 
 runtime/valhalla/inlinetypes/ClassInitializationFailuresTest.java 8274131 linux-aarch64-debug,macosx-aarch64-debug


### PR DESCRIPTION
1. Resolve merge conflicts from ProblemList.txt, JtregNativeHotspot.gmk and Flags.java
2. In Flags.java, the upstream JdkNext and Valhalla repos are defining
conflicting const using the same value 1<<21. It is assigned to
FROM_SOURCE in JdkNext, VALUE_CLASS in Valhalla. Change VALUE_CLASS to 
1<<20.

issue: #3

Signed-off-by: Hang Shao <hangshao@ca.ibm.com>