### PR TITLE
Add OPENJDK_VERSION_STRING to openj9_version_info.h

### DIFF
--- a/closed/openj9_version_info.h.in
+++ b/closed/openj9_version_info.h.in
@@ -32,6 +32,7 @@
 #define J9VERSION_STRING          "@VERSION_STRING@"
 #define OPENJDK_SHA               "@OPENJDK_SHA@"
 #define OPENJDK_TAG               "@OPENJDK_TAG@"
+#define OPENJDK_VERSION_STRING    "@VERSION_STRING@"
 #define J9JVM_VERSION_STRING      "@OPENJ9_VERSION_STRING@"
 #define OPENJ9_TAG                "@OPENJ9_TAG@"
 #define J9JDK_EXT_VERSION         "@J9JDK_EXT_VERSION@"


### PR DESCRIPTION
Port from https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/1095 so the Valhalla nightly build will pass with https://github.com/eclipse-openj9/openj9/pull/22626.