### PR TITLE
Update TestIllegalLoadableDescriptors error message expectation

### DIFF
--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/classfileparser/TestIllegalLoadableDescriptors.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/classfileparser/TestIllegalLoadableDescriptors.java
@@ -39,7 +39,7 @@ public class TestIllegalLoadableDescriptors {
           Class newClass = Class.forName("LDTest");
       } catch (java.lang.ClassFormatError e) {
           gotException = true;
-          if (!e.getMessage().contains("Descriptor from LoadableDescriptors attribute at index \"33\" in class LDTest has illegal signature \"[V")) {
+          if (!e.getMessage().contains("Invalid field descriptor found in LoadableDescriptors attribute")) {
               throw new RuntimeException( "Wrong ClassFormatError: " + e.getMessage());
           }
       }


### PR DESCRIPTION
Relax the assertion in TestIllegalLoadableDescriptors to match the updated ClassFormatError message for invalid LoadableDescriptors entries.

Related to https://github.com/eclipse-openj9/openj9/pull/23660