### PR TITLE
Disable SCC for TestJNIIsValueObject

### DIFF
--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/TestJNIIsValueObject.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/TestJNIIsValueObject.java
@@ -21,6 +21,12 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2026, 2026 All Rights Reserved
+ * ===========================================================================
+ */
+
 package runtime.valhalla.inlinetypes;
 
 import jdk.test.lib.Asserts;
@@ -30,7 +36,7 @@ import jdk.test.lib.Asserts;
  * @summary Test JNI IsValueObject with inline types
  * @library /test/lib
  * @enablePreview
- * @run main/othervm/native --enable-native-access=ALL-UNNAMED
+ * @run main/othervm/native -Xshareclasses:none --enable-native-access=ALL-UNNAMED
  *                          runtime.valhalla.inlinetypes.TestJNIIsValueObject
  */
 public class TestJNIIsValueObject {


### PR DESCRIPTION
Scc uses the wrong class version for migrated value classes.
Related: https://github.com/eclipse-openj9/openj9/pull/23625





