### PR TITLE
Modify PreLoadFailuresDoNotImpactApplicationTest for OpenJ9

### DIFF
--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/classloading/PreLoadFailuresDoNotImpactApplicationTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/classloading/PreLoadFailuresDoNotImpactApplicationTest.java
@@ -33,6 +33,12 @@
  * @run junit runtime.valhalla.inlinetypes.classloading.PreLoadFailuresDoNotImpactApplicationTest
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2026, 2026 All Rights Reserved
+ * ===========================================================================
+ */
+
 package runtime.valhalla.inlinetypes.classloading;
 
 import java.io.IOException;
@@ -98,10 +104,10 @@ class PreLoadFailuresDoNotImpactApplicationTest {
             }
             case "InnerValue": {
                 // First access failure: when Outer is preloading Inner via LoadableDescriptor.
-                // Second access failure: when we try to load Inner the first time (LoadableDescriptor).
+                // Second access failure: when we try to load Inner the first time (LoadableDescriptor). (OpenJ9 does not do this.)
                 // Third access failure: when class linking occurs (LoadableDescriptor).
                 // Fourth access and onwards should succeed.
-                if (attempts++ < 3) {
+                if (attempts++ < 2) {
                     throw new ClassNotFoundException("purposeful exception: we can't find this class");
                 }
                 return customLoadSimple(name);


### PR DESCRIPTION
This test is written based on the assumption that classes in a LoadableDescriptors attribute will be loaded during linking which is optional for a jvm. This is not done in OpenJ9.

The spec draft mentions this as optional behavior https://cr.openjdk.org/~dlsmith/jep401/jep401-20260225/specs/value-objects-jvms.html#jvms-5.4. I don't believe there is a useful reason for J9 to do this currently.


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).
