### PR TITLE
Remove disabling scc from Valhalla tests

### DIFF
--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/TestJNIHasIdentity.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/TestJNIHasIdentity.java
@@ -21,12 +21,6 @@
  * questions.
  */
 
-/*
- * ===========================================================================
- * (c) Copyright IBM Corp. 2026, 2026 All Rights Reserved
- * ===========================================================================
- */
-
 package runtime.valhalla.inlinetypes;
 
 import jdk.test.lib.Asserts;
@@ -36,7 +30,7 @@ import jdk.test.lib.Asserts;
  * @summary Test JNI HasIdentity with inline types
  * @library /test/lib
  * @enablePreview
- * @run main/othervm/native -Xshareclasses:none --enable-native-access=ALL-UNNAMED
+ * @run main/othervm/native --enable-native-access=ALL-UNNAMED
  *                          runtime.valhalla.inlinetypes.TestJNIHasIdentity
  */
 public class TestJNIHasIdentity {

--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/field_layout/ValueComparisonTest.java
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/field_layout/ValueComparisonTest.java
@@ -21,12 +21,6 @@
  * questions.
  */
 
-/*
- * ===========================================================================
- * (c) Copyright IBM Corp. 2026, 2026 All Rights Reserved
- * ===========================================================================
- */
-
  /*
  * @test
  * @key randomness
@@ -35,7 +29,7 @@
  * @modules java.base/jdk.internal.vm.annotation
  * @enablePreview
  * @compile ValueClassGenerator.java ValueComparisonTest.java
- * @run main/othervm -Xshareclasses:none -XX:MaxNodeLimit=100000 runtime.valhalla.inlinetypes.field_layout.ValueComparisonTest
+ * @run main/othervm -XX:MaxNodeLimit=100000 runtime.valhalla.inlinetypes.field_layout.ValueComparisonTest
  */
 
 package runtime.valhalla.inlinetypes.field_layout;

--- a/test/hotspot/jtreg/serviceability/jvmti/valhalla/HeapwalkDupClasses/HeapwalkDupClasses.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/valhalla/HeapwalkDupClasses/HeapwalkDupClasses.java
@@ -22,19 +22,13 @@
  */
 
 /*
- * ===========================================================================
- * (c) Copyright IBM Corp. 2026, 2026 All Rights Reserved
- * ===========================================================================
- */
-
-/*
  * @test
  * @bug 8368799
  * @summary Verify heapwalking API does not report array classes several times.
  * @requires vm.jvmti
  * @modules java.base/jdk.internal.vm.annotation java.base/jdk.internal.value
  * @enablePreview
- * @run main/othervm/native -Xshareclasses:none -agentlib:HeapwalkDupClasses HeapwalkDupClasses
+ * @run main/othervm/native -agentlib:HeapwalkDupClasses HeapwalkDupClasses
  */
 
 import java.lang.ref.Reference;

--- a/test/jdk/java/lang/invoke/VarHandles/VarHandleTestExact.java
+++ b/test/jdk/java/lang/invoke/VarHandles/VarHandleTestExact.java
@@ -22,30 +22,24 @@
  */
 
 /*
- * ===========================================================================
- * (c) Copyright IBM Corp. 2026, 2026 All Rights Reserved
- * ===========================================================================
- */
-
-/*
  * @test
  * @modules java.base/jdk.internal.access.foreign
  * @modules java.base/jdk.internal.foreign.layout
  *
- * @run junit/othervm -Xverify:all -Xshareclasses:none
+ * @run junit/othervm -Xverify:all
  *   -Djdk.internal.foreign.SHOULD_ADAPT_HANDLES=false
  *   VarHandleTestExact
- * @run junit/othervm -Xverify:all -Xshareclasses:none
+ * @run junit/othervm -Xverify:all
  *   -Djdk.internal.foreign.SHOULD_ADAPT_HANDLES=false
  *   -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=true
  *   -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=true
  *   VarHandleTestExact
- * @run junit/othervm -Xverify:all -Xshareclasses:none
+ * @run junit/othervm -Xverify:all
  *   -Djdk.internal.foreign.SHOULD_ADAPT_HANDLES=false
  *   -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=false
  *   -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=false
  *   VarHandleTestExact
- * @run junit/othervm -Xverify:all -Xshareclasses:none
+ * @run junit/othervm -Xverify:all
  *   -Djdk.internal.foreign.SHOULD_ADAPT_HANDLES=false
  *   -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=false
  *   -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=true

--- a/test/jdk/java/lang/invoke/unreflect/UnreflectTest.java
+++ b/test/jdk/java/lang/invoke/unreflect/UnreflectTest.java
@@ -22,18 +22,12 @@
  */
 
 /*
- * ===========================================================================
- * (c) Copyright IBM Corp. 2026, 2026 All Rights Reserved
- * ===========================================================================
- */
-
-/*
  * @test
  * @bug 8238358 8247444
  * @summary Test Lookup::unreflectSetter and Lookup::unreflectVarHandle on
  *          trusted final fields (declared in hidden classes and records)
- * @run junit/othervm -Xshareclasses:none --enable-final-field-mutation=ALL-UNNAMED -DwriteAccess=true UnreflectTest
- * @run junit/othervm -Xshareclasses:none --illegal-final-field-mutation=deny -DwriteAccess=false UnreflectTest
+ * @run junit/othervm --enable-final-field-mutation=ALL-UNNAMED -DwriteAccess=true UnreflectTest
+ * @run junit/othervm --illegal-final-field-mutation=deny -DwriteAccess=false UnreflectTest
  */
 
 import java.io.IOException;

--- a/test/jdk/java/lang/reflect/valhalla/ValueClassesReflectionTest.java
+++ b/test/jdk/java/lang/reflect/valhalla/ValueClassesReflectionTest.java
@@ -22,18 +22,12 @@
  */
 
 /*
- * ===========================================================================
- * (c) Copyright IBM Corp. 2026, 2026 All Rights Reserved
- * ===========================================================================
- */
-
-/*
  * @test
  * @bug 8334334
  * @summary reflection test for value classes
  * @enablePreview
  * @compile ValueClassesReflectionTest.java
- * @run testng/othervm -Xshareclasses:none ValueClassesReflectionTest
+ * @run testng/othervm ValueClassesReflectionTest
  */
 
 import java.lang.annotation.*;

--- a/test/jdk/valhalla/valuetypes/ObjectMethodsViaCondy.java
+++ b/test/jdk/valhalla/valuetypes/ObjectMethodsViaCondy.java
@@ -22,17 +22,11 @@
  */
 
 /*
- * ===========================================================================
- * (c) Copyright IBM Corp. 2026, 2026 All Rights Reserved
- * ===========================================================================
- */
-
-/*
  * @test
  * @summary Test ObjectMethods::bootstrap call via condy
  * @modules java.base/jdk.internal.value
  * @enablePreview
- * @run testng/othervm -Xshareclasses:none ObjectMethodsViaCondy
+ * @run testng/othervm ObjectMethodsViaCondy
  */
 
 import java.io.IOException;

--- a/test/jdk/valhalla/valuetypes/UseValueClassTest.java
+++ b/test/jdk/valhalla/valuetypes/UseValueClassTest.java
@@ -21,12 +21,6 @@
  * questions.
  */
 
-/*
- * ===========================================================================
- * (c) Copyright IBM Corp. 2026, 2026 All Rights Reserved
- * ===========================================================================
- */
-
 import static org.junit.jupiter.api.Assertions.*;
 
 import org.junit.jupiter.api.Test;
@@ -59,8 +53,8 @@ import java.time.ZonedDateTime;
  * @test
  * @summary Test that classes are value classes or not depending on --enable-preview
  * @modules java.base/jdk.internal.misc
- * @run junit/othervm -Xshareclasses:none --enable-preview UseValueClassTest
- * @run junit/othervm -Xshareclasses:none UseValueClassTest
+ * @run junit/othervm -Xlog --enable-preview UseValueClassTest
+ * @run junit/othervm -Xlog UseValueClassTest
  */
 
 public class UseValueClassTest {

--- a/test/jdk/valhalla/valuetypes/ValueClassCompatibilityTest.java
+++ b/test/jdk/valhalla/valuetypes/ValueClassCompatibilityTest.java
@@ -22,19 +22,13 @@
  */
 
 /*
- * ===========================================================================
- * (c) Copyright IBM Corp. 2026, 2026 All Rights Reserved
- * ===========================================================================
- */
-
-/*
  * @test
  * @bug 8377576
  * @summary Test jdk.internal.value.ValueClass with and without preview
  * @modules java.base/jdk.internal.misc
  *          java.base/jdk.internal.value
- * @run junit/othervm -Xshareclasses:none ValueClassCompatibilityTest
- * @run junit/othervm -Xshareclasses:none --enable-preview ValueClassCompatibilityTest
+ * @run junit ValueClassCompatibilityTest
+ * @run junit/othervm --enable-preview ValueClassCompatibilityTest
  */
 
 import java.util.ArrayList;

--- a/test/jdk/valhalla/valuetypes/ValueClassPreviewTest.java
+++ b/test/jdk/valhalla/valuetypes/ValueClassPreviewTest.java
@@ -22,17 +22,11 @@
  */
 
 /*
- * ===========================================================================
- * (c) Copyright IBM Corp. 2026, 2026 All Rights Reserved
- * ===========================================================================
- */
-
-/*
  * @test
  * @summary Test jdk.internal.value.ValueClass against preview-only things
  * @modules java.base/jdk.internal.value
  * @enablePreview
- * @run junit/othervm -Xshareclasses:none ValueClassPreviewTest
+ * @run junit ValueClassPreviewTest
  */
 
 import java.util.Optional;


### PR DESCRIPTION
Recent upstream changes lead to all scc being disabled for all OpenJDK Valhalla tests so these are no longer needed. https://github.com/adoptium/aqa-tests/pull/7119

This reverts commit 8b7d07006b2b179a209d247e6807f6cd62f0d61f.
This reverts commit 3055b66bb074629b2fb869863821afa75c0bf541.
This reverts commit b5e2c118a07168ddcc11d2609761edf13b199318.

Fixes: https://github.com/ibmruntimes/openj9-openjdk-jdk.valuetypes/issues/40

test run: https://hyc-runtimes-jenkins.swg-devops.com/view/Valhalla%20Tests/job/Test_JDKnext_valhalla_openjdk_x86-64_linux/92/


---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).
