### PR TITLE
Fix GetStaticFieldID call ordering in InlineWithJni test

### DIFF
--- a/test/hotspot/jtreg/runtime/valhalla/inlinetypes/libInlineWithJni.c
+++ b/test/hotspot/jtreg/runtime/valhalla/inlinetypes/libInlineWithJni.c
@@ -25,9 +25,9 @@
 
 JNIEXPORT void JNICALL
 Java_runtime_valhalla_inlinetypes_InlineWithJni_doJniMonitorEnter(JNIEnv *env, jobject obj) {
-    int ret = (*env)->MonitorEnter(env, obj);
     jclass class = (*env)->GetObjectClass(env, obj);
     jfieldID fieldId = (*env)->GetStaticFieldID(env, class, "returnValue", "I");
+    int ret = (*env)->MonitorEnter(env, obj);
     (*env)->SetStaticIntField(env, class, fieldId, ret);
 }
 


### PR DESCRIPTION
Fix related to issue: https://github.com/eclipse-openj9/openj9/issues/24013
Move GetStaticFieldID before MonitorEnter in InlineWithJni test

Retrieve the field ID before calling MonitorEnter() so the
test does not perform GetStaticFieldID() when a pending
exception exists.
