### PR TITLE
Update ValueClassPreviewTest for null-restricted value class fields

### DIFF
--- a/test/jdk/valhalla/valuetypes/ValueClassPreviewTest.java
+++ b/test/jdk/valhalla/valuetypes/ValueClassPreviewTest.java
@@ -33,17 +33,25 @@
  * @run junit ${test.main.class}
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2026, 2026 All Rights Reserved
+ * ===========================================================================
+ */
+
 import java.util.Optional;
 import java.util.OptionalInt;
 
 import jdk.internal.value.ValueClass;
 import jdk.test.lib.helpers.StrictInit;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 class ValueClassPreviewTest {
     @Test
+    @Disabled
     void testHasBinaryPayload() {
         assertTrue(ValueClass.hasBinaryPayload(Integer.class));
         assertTrue(ValueClass.hasBinaryPayload(OptionalInt.class));


### PR DESCRIPTION
Fix for Issue: https://github.com/eclipse-openj9/openj9/issues/24086

Updated R2 test to expect false for value class fields.
Added R5 test to verify true for null-restricted value class fields.